### PR TITLE
Moved build options from README to build-template.sbt

### DIFF
--- a/build-template.sbt
+++ b/build-template.sbt
@@ -1,28 +1,28 @@
 // Choose either one and build
 
-// Spark 3.1.2
-name := "COVID-19-SPARK"
+// // Spark 3.1.2
+// name := "COVID-19-SPARK"
 
-version := "0.1"
+// version := "0.1"
 
-scalaVersion := "2.12.10"
+// scalaVersion := "2.12.10"
 
-libraryDependencies ++= Seq(
-  // https://mvnrepository.com/artifact/org.apache.spark/spark-core
-  "org.apache.spark" %% "spark-core" % "3.1.2",
-  // https://mvnrepository.com/artifact/org.apache.spark/spark-sql
-  "org.apache.spark" %% "spark-sql" % "3.1.2"
-)
+// libraryDependencies ++= Seq(
+//   // https://mvnrepository.com/artifact/org.apache.spark/spark-core
+//   "org.apache.spark" %% "spark-core" % "3.1.2",
+//   // https://mvnrepository.com/artifact/org.apache.spark/spark-sql
+//   "org.apache.spark" %% "spark-sql" % "3.1.2"
+// )
 
-// Spark 2.4.8
-name := "COVID-19-SPARK"
+// // Spark 2.4.8
+// name := "COVID-19-SPARK"
 
-version := "0.1"
+// version := "0.1"
 
-scalaVersion := "2.11.12"
+// scalaVersion := "2.11.12"
 
-libraryDependencies ++= Seq(
-  "org.apache.spark" % "spark-core_2.11" % "2.4.8",
-  "org.apache.spark" % "spark-sql_2.11" % "2.4.8",
-  "org.apache.spark" %% "spark-hive" % "2.4.8"
-)
+// libraryDependencies ++= Seq(
+//   "org.apache.spark" % "spark-core_2.11" % "2.4.8",
+//   "org.apache.spark" % "spark-sql_2.11" % "2.4.8",
+//   "org.apache.spark" %% "spark-hive" % "2.4.8"
+// )


### PR DESCRIPTION
We will use README for a concise summary of the project, as per project requirements.